### PR TITLE
Fix: resolve LLM hallucination via parameter tuning and flood data fo…

### DIFF
--- a/frontend/app/api/fireworks/route.js
+++ b/frontend/app/api/fireworks/route.js
@@ -40,11 +40,11 @@ export async function POST(request) {
       body: JSON.stringify({
         model: model,
         max_tokens: 3072,
-        top_p: 1,
+        top_p: 0.9,
         top_k: 40,
-        presence_penalty: 0,
-        frequency_penalty: 1,
-        temperature: 0.1,
+        presence_penalty: 0.3,
+        frequency_penalty: 0.4,
+        temperature: 0.3,
         messages: [{ content: prompt, role: "user" }],
       }),
     });

--- a/frontend/app/components/businessPlan.js
+++ b/frontend/app/components/businessPlan.js
@@ -24,23 +24,15 @@ function BusinessPlan() {
     floods.forEach(flood => {
       if (!flood.year || !flood.distance) return;
       const year = flood.year;
-  
+
       if (flood.distance < 5000) {
         groupedFloods.lessThan5km[year] = (groupedFloods.lessThan5km[year] || 0) + 1;
       } else {
         groupedFloods.over5km[year] = (groupedFloods.over5km[year] || 0) + 1;
       }
     });
-  
-    let resultText = '';
-    for (const [year, count] of Object.entries(groupedFloods.lessThan5km)) {
-      resultText += `In ${year}, there were ${count} floods less than 5km away.\n`;
-    }
-    for (const [year, count] of Object.entries(groupedFloods.over5km)) {
-      resultText += `In ${year}, there were ${count} floods over 5km away.\n`;
-    }
-  
-    return resultText;
+
+    return groupedFloods;
   };
 
   const sendPromptToFireworks = async (prompt) => {
@@ -61,7 +53,7 @@ function BusinessPlan() {
 
   const handleSubmit = async () => {
     setLoading(true); 
-    const groupedFloods = groupFloodsByDistance(markers);
+    const groupedFloods = markers.length === 0 ? "NO_FLOOD_DATA_AVAILABLE" : groupFloodsByDistance(markers);
     if (value.length < 10) {
       window.alert('Please expand on your business idea!');
       return;


### PR DESCRIPTION
…rmat correction

- Rebalance Fireworks AI params: lower frequency_penalty (1→0.4) and raise temperature (0.1→0.3) to break deterministic synonym-loop hallucinations; add presence_penalty (0→0.3) and tighten top_p (1→0.9)
- Fix groupFloodsByDistance to return structured object instead of prose string so JSON.stringify in the prompt receives the correct shape
- Guard against empty flood markers with explicit NO_FLOOD_DATA_AVAILABLE sentinel to prevent the LLM filling in fabricated flood history